### PR TITLE
Add methods for querying and changing LIFX matrix devices

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -918,6 +918,12 @@ class Light(Device):
         self.hev_cycle_configuration = None
         self.last_hev_cycle_result = None
         self.effect = {"effect": None}
+        # matrix devices: Tile, Candle, Path, Spot, Ceiling
+        self.chain = {}
+        self.chain_length = 0
+        self.tile_devices = []
+        self.tile_devices_count = 0
+        self.tile_device_width = 0
         # Only used by a Lifx Switch. Will be populated with either True or False for each relay index if `get_rpower` called.
         # At the moment we assume the switch to be 4 relays. This will likely work with the 2 relays switch as well, but only the first two values
         # in this array will contain useful data.
@@ -1611,6 +1617,136 @@ class Light(Device):
         if resp:
             self.last_hev_cycle_result = LAST_HEV_CYCLE_RESULT.get(resp.result)
 
+    def get_device_chain(self, callb=None):
+        """Convenience method to get the devices on a matrix chain.
+
+        This method only works on LIFX matrix devices which include the Tile,
+        Candle, Path, Spot and Ceiling.
+
+        The LIFX protocol definition uses the terms tile and chain, even
+        though the actual Tile product has been discontinued and is/was the
+        only one to have more than one tile on the chain.
+
+        This method populates the tile_devices, tile_devices_count and
+        tile_device_width attributes of the corresponding Light object.
+
+        :param callb: Callable to be used when the response is received.
+        :type callb: callable
+        :returns: None
+        :rtype: None
+        """
+        if products_dict[self.product].matrix is True:
+            self.req_with_resp(TileGetDeviceChain, TileStateDeviceChain, callb=callb)
+
+    def resp_set_tiledevicechain(self, resp):
+        if resp:
+            self.tile_devices = [tile_device for tile_device in resp.tile_devices]
+            self.tile_devices_count = resp.tile_devices_count
+            self.tile_device_width = self.tile_devices[0]["width"]
+
+    def get64(self, tile_index=0, length=1, width=None, callb=None):
+        """Convenience method to get the state of zones on tiles in a chain.
+
+        This method populates returns the state of at least one but up to
+        five tiles worth of zones, with up to 64 zones per tile. This is stored
+        in the chain attribute of the Light which is an array that has the
+        tile_index as the key and a list of 64 HSBK tuples as the value.
+
+        :param tile_index: starting tile on the target chain
+        :type tile_index: int
+        :param length: how many tiles to target including the starting tile
+        :type length: int
+        :param width: how many zones per row on the target tile
+        :type width: int
+        :param callb: Callable to be used when the response is received.
+        :type callb: callable
+        :rtype: None
+        """
+        if width is None:
+            if self.tile_device_width == 0:
+                return
+            width = self.tile_device_width
+
+        if products_dict[self.product].chain is True:
+            length = 5
+
+        for i in range(tile_index, length):
+            args = {
+                "tile_index": i,
+                "length": 1,
+                "x": 0,
+                "y": 0,
+                "width": width,
+            }
+
+            self.req_with_resp(
+                msg_type=TileGet64, response_type=TileState64, payload=args, callb=callb
+            )
+
+    def resp_set_tile64(self, resp):
+        if resp and isinstance(resp, TileState64):
+            self.chain[resp.tile_index] = resp.colors
+            self.chain_length = len(self.chain)
+
+    def set64(
+        self, tile_index=0, x=0, y=0, width=None, duration=0, colors=None, callb=None
+    ):
+        """Convenience method to set 64 colors on a tile.
+
+        You can either provide the width of the target tile or
+        use the get_device_chain method to retrieve the value
+        from the target light. If the width is not provided,
+        this method will return without sending a packet.
+
+        The x and y parameters specify the row and column
+        starting point from which to change the zones and
+        the amount of colors provided will determine how many zones
+        are changed.
+
+        To change all zones to the same color, use the set_color
+        method.
+
+        Note this method does not return a response even if requested.
+
+        :param tile_index: the starting tile in a chain to target
+        :type tile_index: int
+        :param x: the starting column to target on the target tile
+        :type x: int
+        :param y: the starting row to target on the target tile
+        :type y: int
+        :param width: how many zones per row on the target tile
+        :type width: int
+        :param duration: how long in seconds to transition to the new colors
+        :type duration: int
+        :param colors: up to 64 color tuples to apply to the target zones
+        :type colors: list[tuple[int, float, float, int]]
+        :rtype: None
+        """
+
+        if width is None:
+            if self.tile_device_width == 0:
+                return
+            width = self.tile_device_width
+
+        if len(colors) < 64:
+            for _ in range(64 - len(colors)):
+                colors.append((0, 0, 0, 3500))
+
+        if len(colors) > 64:
+            colors = colors[:64]
+
+        payload = {
+            "tile_index": tile_index,
+            "length": 1,
+            "x": x,
+            "y": y,
+            "width": width,
+            "duration": duration * 1000,
+            "colors": colors,
+        }
+
+        self.fire_and_forget(TileSet64, payload)
+
     def get_tile_effect(self, callb=None):
         """Convenience method to get the currently running effect on a Tile or Candle.
 
@@ -1682,8 +1818,8 @@ class Light(Device):
             typ = effect if effect in [e.value for e in TileEffectType] else 0
 
         if typ is TileEffectType.SKY.value:
-            if speed is None:
-                speed = 50
+            speed = floor(sky_speed * 1000) if sky_speed is not None else 50000
+
             if sky_type is None:
                 sky_type = TileEffectSkyType.CLOUDS.value
             elif type(sky_type) == str:

--- a/aiolifx/unpack.py
+++ b/aiolifx/unpack.py
@@ -473,6 +473,92 @@ def unpack_lifx_message(packed_message):
             target_addr, source_id, seq_num, payload, ack_requested, response_requested
         )
 
+    elif message_type == MSG_IDS[TileGetDeviceChain]:  # 701
+        message = TileGetDeviceChain(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[TileStateDeviceChain]:  # 702
+        start_index = struct.unpack("B", payload_str[0:1])[0]
+        tile_devices_count = struct.unpack(
+            "B", payload_str[len(payload_str) - 1 : len(payload_str)]
+        )[0]
+
+        tile_devices = []
+        for i in range(tile_devices_count):
+            tile_devices.append(getTile(payload_str[1 + (i * 55) : 55 + (i * 55)]))
+
+        payload = {
+            "start_index": start_index,
+            "tile_devices": tile_devices,
+            "tile_devices_count": tile_devices_count,
+        }
+        message = TileStateDeviceChain(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[TileGet64]:  # 707
+        tile_index = struct.unpack("B", payload_str[0:1])[0]
+        length = struct.unpack("B", payload_str[1:2])[0]
+        x = struct.unpack("B", payload_str[3:4])[0]
+        y = struct.unpack("B", payload_str[4:5])[0]
+        width = struct.unpack("B", payload_str[5:6])[0]
+        payload = {
+            "tile_index": tile_index,
+            "length": length,
+            "x": x,
+            "y": y,
+            "width": width,
+        }
+        message = TileGet64(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[TileState64]:  # 711
+        tile_index = struct.unpack("B", payload_str[0:1])[0]
+        x = struct.unpack("B", payload_str[2:3])[0]
+        y = struct.unpack("B", payload_str[3:4])[0]
+        width = struct.unpack("B", payload_str[4:5])[0]
+        colors = []
+        for i in range(64):
+            color = struct.unpack("H" * 4, payload_str[5 + (i * 8) : 13 + (i * 8)])
+            colors.append(color)
+
+        payload = {
+            "tile_index": tile_index,
+            "x": x,
+            "y": y,
+            "width": width,
+            "colors": colors,
+        }
+        message = TileState64(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[TileSet64]:  # 715
+        tile_index = struct.unpack("B", payload_str[0:1])[0]
+        length = struct.unpack("B", payload_str[1:2])[0]
+        x = struct.unpack("B", payload_str[3:4])[0]
+        y = struct.unpack("B", payload_str[4:5])[0]
+        width = struct.unpack("B", payload_str[5:6])[0]
+        duration = struct.unpack("I", payload_str[6:10])[0]
+        colors = []
+        for i in range(64):
+            color = struct.unpack("H" * 4, payload_str[10 + (i * 8) : 18 + (i * 8)])
+            colors.append(color)
+        payload = {
+            "tile_index": tile_index,
+            "length": length,
+            "x": x,
+            "y": y,
+            "width": width,
+            "duration": duration,
+            "colors": colors,
+        }
+        message = TileSet64(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
     elif message_type == MSG_IDS[TileStateTileEffect]:  # 720
         instanceid = struct.unpack("I", payload_str[1:5])[0]
         effect = struct.unpack("B", payload_str[5:6])[0]
@@ -653,6 +739,41 @@ class ButtonTargetType(Enum):
     GROUP = 5
     SCENE = 6
     DEVICE_RELAYS = 7
+
+
+def getTile(payload_str):
+    accel_meas_x = struct.unpack("h", payload_str[0:2])[0]
+    accel_meas_y = struct.unpack("h", payload_str[2:4])[0]
+    accel_meas_z = struct.unpack("h", payload_str[4:6])[0]
+    # 6:8
+    user_x = struct.unpack("f", payload_str[8:12])[0]
+    user_y = struct.unpack("f", payload_str[12:16])[0]
+    width = struct.unpack("B", payload_str[16:17])[0]
+    height = struct.unpack("B", payload_str[17:18])[0]
+    # 18:19
+    device_version_vendor = struct.unpack("I", payload_str[19:23])[0]
+    device_version_product = struct.unpack("I", payload_str[23:27])[0]
+    # 27:31
+    firmware_build = struct.unpack("Q", payload_str[31:39])[0]
+    # 39:47
+    firmware_version_minor = struct.unpack("H", payload_str[47:49])[0]
+    firmware_version_major = struct.unpack("H", payload_str[49:51])[0]
+    # 51:55
+
+    return {
+        "accel_meas_x": accel_meas_x,
+        "accel_meas_y": accel_meas_y,
+        "accel_meas_z": accel_meas_z,
+        "user_x": user_x,
+        "user_y": user_y,
+        "width": width,
+        "height": height,
+        "device_version_vendor": device_version_vendor,
+        "device_version_product": device_version_product,
+        "firmware_build": firmware_build,
+        "firmware_version_minor": firmware_version_minor,
+        "firmware_version_major": firmware_version_major,
+    }
 
 
 def getBacklightColor(payload_str):


### PR DESCRIPTION
This adds most (but not all) the Tile messages which are required for querying and controlling LIFX Tile, Candle, Path, Spot and Ceiling devices. This PR includes the fix in #83 so you can drop that if you merge this one.